### PR TITLE
Adds play next and play previous functionality to arrows in Uniplayer

### DIFF
--- a/src/modules/queue/state/mutations.js
+++ b/src/modules/queue/state/mutations.js
@@ -17,7 +17,7 @@ export const updatePlaying = updateQL(
 	`
 ).with(({track}) => set('player', 'currentlyPlaying')(track));
 
-export const playNextFromQueue = updateQL(
+export const playNthNextFromQueue = updateQL(
 	gql`
 		query PlayNextQuery($playlist: String!) {
 			playlist(where: {name: $playlist}) {
@@ -34,7 +34,7 @@ export const playNextFromQueue = updateQL(
 			}
 		}
 	`
-).with(() => state => {
+).with(({n}) => state => {
 	//prettier-ignore
 	const {
 		playlist: {
@@ -47,19 +47,14 @@ export const playNextFromQueue = updateQL(
 		}
 	} = state;
 
-	const track = findNextTrack(tracks, has({id}));
+	const track = findNthNextTrack(tracks, has({id}), n);
 	return set('player', 'currentlyPlaying')(track)(state);
 });
 
-function findNextTrack(tracks, pred) {
+function findNthNextTrack(tracks, pred, n) {
 	const idx = _.findIndex(tracks, pred);
-	const nextIdx = idx + 1;
-	if (!nextIdx) {
+	if (idx === -1) {
 		return null;
 	}
-	if (nextIdx === tracks.length) {
-		return tracks[0];
-	}
-
-	return tracks[nextIdx];
+	return tracks[(idx + n) % tracks.length];
 }

--- a/src/modules/uniplayer/components/Uniplayer.jsx
+++ b/src/modules/uniplayer/components/Uniplayer.jsx
@@ -149,7 +149,7 @@ class Uniplayer extends React.Component {
 					onPause={this.onPause}
 					onBuffer={() => console.log('onBuffer')}
 					onSeek={e => console.log('onSeek', e)}
-					onEnded={this.props.playNextFromQueue}
+					onEnded={this.props.playNext}
 					onError={e => console.log('onError', e)}
 					onProgress={this.onProgress}
 					onDuration={this.onDuration}
@@ -189,9 +189,9 @@ class Uniplayer extends React.Component {
 				<div className="uniplayer-middle">
 					<div className="player-controls">
 						<div className="player-buttons">
-							<div className="arrow previous" />
+							<div className="arrow previous" onClick={this.props.playPrev} />
 							<div className={'play-button' + player.status} onClick={this.playToggle} />
-							<div className="arrow next" />
+							<div className="arrow next" onClick={this.props.playNext} />
 						</div>
 						<div className="playback-holder">
 							<Duration className="duration" seconds={this.state.duration * this.state.played} />

--- a/src/modules/uniplayer/components/UniplayerContainer.jsx
+++ b/src/modules/uniplayer/components/UniplayerContainer.jsx
@@ -18,14 +18,14 @@ const query = gql`
 	${TrackFragments.all}
 `;
 
-const PLAY_NEXT_FROM_QUEUE = gql`
-	mutation playNextFromQueue($playlist: String!) {
-		playNextFromQueue(playlist: $playlist) @client
+const PLAY_NTH_NEXT_FROM_QUEUE = gql`
+	mutation playNthNextFromQueue($playlist: String!, $n: Integer!) {
+		playNthNextFromQueue(playlist: $playlist, n: $n) @client
 	}
 `;
 
 const Composed = adapt({
-	playNextFromQueue: <Mutation mutation={PLAY_NEXT_FROM_QUEUE} />,
+	playNthNextFromQueue: <Mutation mutation={PLAY_NTH_NEXT_FROM_QUEUE} />,
 	data: ({render}) => <Query query={query}>{({data}) => render(data)}</Query>,
 	playlist: <WithPlaylistId />
 });
@@ -37,12 +37,13 @@ export default function UniplayerContainer() {
 				data: {
 					player: {currentlyPlaying}
 				},
-				playNextFromQueue,
+				playNthNextFromQueue,
 				playlist
 			}) => (
 				<Uniplayer
 					currentlyPlaying={currentlyPlaying}
-					playNextFromQueue={() => playNextFromQueue({variables: {playlist}})}
+					playNext={_ => playNthNextFromQueue({variables: {playlist, n: 1}})}
+					playPrev={_ => playNthNextFromQueue({variables: {playlist, n: -1}})}
 				/>
 			)}
 		</Composed>


### PR DESCRIPTION
All I did was change the `playNextFromQueue` mutation to take a parameter `n` which determines how many songs forward to skip. Negative numbers allow going back.