### PR TITLE
Fix song adding from SearchResults

### DIFF
--- a/src/modules/search/components/Search.jsx
+++ b/src/modules/search/components/Search.jsx
@@ -2,45 +2,40 @@ import {VelocityTransitionGroup} from 'velocity-react';
 import React from 'react';
 import styled from 'styled-components';
 
-import onClickOutside from 'react-onclickoutside';
-
 import SearchBackground from './SearchBackground';
 import SearchBar from './SearchBar';
 import SearchResults from './SearchResults';
 import * as animations from '../../common/animations';
 
-class Search extends React.Component {
-	handleClickOutside({target: {dataset: {id} = {id: null}}}) {
-		if (this.props.isSearchOpen) {
-			if (id !== 'show-hide-search') {
-				this.props.toggleSearch();
-			}
-			this.props.clearSearch();
-		}
-	}
-
-	render() {
-		const {query, setSearch, results, enqueue, isSearchOpen} = this.props;
-
-		return (
-			<SearchHolder>
-				<VelocityTransitionGroup
-					enter={{animation: animations.slideDownExpand.in, duration: 200}}
-					leave={animations.slideDownExpand.out}
-				>
-					{isSearchOpen && <SearchBar query={query} onChange={setSearch} />}
-				</VelocityTransitionGroup>
-				<SearchBackground isSearchOpen={isSearchOpen}>
-					{results.length > 0 && <SearchResults results={results} enqueue={enqueue} />}
-				</SearchBackground>
-			</SearchHolder>
-		);
-	}
+export default function Search({
+	query,
+	setSearch,
+	results,
+	enqueue,
+	isSearchOpen,
+	toggleSearch,
+	clearSearch
+}) {
+	return (
+		<SearchHolder>
+			<VelocityTransitionGroup
+				enter={{animation: animations.slideDownExpand.in, duration: 200}}
+				leave={animations.slideDownExpand.out}
+			>
+				{isSearchOpen && <SearchBar query={query} onChange={setSearch} />}
+			</VelocityTransitionGroup>
+			<SearchBackground
+				isSearchOpen={isSearchOpen}
+				toggleSearch={toggleSearch}
+				clearSearch={clearSearch}
+			>
+				{results.length > 0 && <SearchResults results={results} enqueue={enqueue} />}
+			</SearchBackground>
+		</SearchHolder>
+	);
 }
 
 const SearchHolder = styled.div`
 	background: rgb(36, 36, 36);
 	box-shadow: 0px 4px 6px 4px rgba(0, 0, 0, 0.1);
 `;
-
-export default onClickOutside(Search);

--- a/src/modules/search/components/SearchBackground.jsx
+++ b/src/modules/search/components/SearchBackground.jsx
@@ -2,10 +2,11 @@ import {VelocityTransitionGroup} from 'velocity-react';
 import styled from 'styled-components';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import onClickOutside from 'react-onclickoutside';
 
 import zindex from '../../common/zindex';
 
-export default function SearchBackground({isSearchOpen, children}) {
+export default function SearchBackground({isSearchOpen, toggleSearch, clearSearch, children}) {
 	const target = document.getElementById('search-results-target');
 	if (target) {
 		return ReactDOM.createPortal(
@@ -13,7 +14,15 @@ export default function SearchBackground({isSearchOpen, children}) {
 				enter={{animation: 'slideDown', delay: 200, duration: 700}}
 				leave="slideUp"
 			>
-				{isSearchOpen && <StyledSearchBackground>{children}</StyledSearchBackground>}
+				{isSearchOpen && (
+					<Background
+						isSearchOpen={isSearchOpen}
+						toggleSearch={toggleSearch}
+						clearSearch={clearSearch}
+					>
+						{children}
+					</Background>
+				)}
 			</VelocityTransitionGroup>,
 			target
 		);
@@ -22,7 +31,28 @@ export default function SearchBackground({isSearchOpen, children}) {
 	return null;
 }
 
-const StyledSearchBackground = styled.div`
+class OnClickOutsideBackground extends React.Component {
+	handleClickOutside({target: {dataset: {id} = {id: null}}}) {
+		if (this.props.isSearchOpen) {
+			if (id !== 'show-hide-search') {
+				this.props.toggleSearch();
+			}
+			this.props.clearSearch();
+		}
+	}
+
+	render() {
+		const {style, className} = this.props;
+
+		return (
+			<div style={style} className={className}>
+				{this.props.children}
+			</div>
+		);
+	}
+}
+
+const Background = styled(onClickOutside(OnClickOutsideBackground))`
 	background: rgba(25, 25, 25, 0.97);
 	width: 100%;
 	height: 100%;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,6 +71,10 @@ module.exports = (env, argv) => {
 					use: ['babel-loader']
 				},
 				{
+					test: /\.mjs$/,
+					type: 'javascript/auto'
+				},
+				{
 					test: /\.(woff|woff2|eot|ttf|otf)$/,
 					use: ['file-loader']
 				}


### PR DESCRIPTION
On the last merge I switched to using a [Portal](https://reactjs.org/docs/portals.html) for the search background, so that we could actually render it in the container that the queue is in, and not have to do any hacky sizing tricks. It works great.

However, `react-onclickoutside` doesn't know how to handle portals, so it though every click on the background was actually outside of the `Search` component (which it kinda was).

The solution was to move the onClickOutside logic into the search background itself.