### PR TITLE
Added gzip and multiple chunks to webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.6",
+    "compression-webpack-plugin": "^2.0.0",
     "connected-react-router": "^4.3.0",
     "history": "^4.7.2",
     "lodash": "^4.17.10",


### PR DESCRIPTION
Adds compression to the outut bundle; reduces the bundle size by about 60%. Additionally does vendor chunk splitting, so that all the node_modules are bundled separately. The benefit here is that we update those much less often, and they are much larger. So those bundles can be cached by browsers, even as we change the rest of the code.