### PR TITLE
Fix onNext behavior

### DIFF
--- a/src/modules/player/components/Player.tsx
+++ b/src/modules/player/components/Player.tsx
@@ -59,7 +59,6 @@ class Player extends React.Component<$PlayerProps> {
         ref={this.playerRef}
         url={getTrackUrl(currentlyPlaying)}
         playing={playing}
-        loop
         config={{
           soundcloud: {
             options: {


### PR DESCRIPTION
When a song ends, currently it just loops back to the beginning of the song.

That's because some how we started passing the `loop` parameter to `ReactPlayer`.

I just took it out.